### PR TITLE
Fixed normalization to handle uppercase letters

### DIFF
--- a/src/Chronic.Tests/Parsing/BasicExpressionsTests.cs
+++ b/src/Chronic.Tests/Parsing/BasicExpressionsTests.cs
@@ -17,6 +17,18 @@ namespace Chronic.Tests.Parsing
         }
 
         [Fact]
+        public void uppercase_today_is_parsed_correctly()
+        {
+            Parse("TODAY").AssertStartsAt(DateTime.Now.Date);
+        }
+
+        [Fact]
+        public void first_letter_uppercase_today_is_parsed_correctly()
+        {
+            Parse("Today").AssertStartsAt(DateTime.Now.Date);
+        }
+
+        [Fact]
         public void yesterday_is_parsed_correctly()
         {
             Parse("yesterday").AssertStartsAt(DateTime.Now.Date.AddDays(-1));

--- a/src/Chronic/Parser.cs
+++ b/src/Chronic/Parser.cs
@@ -67,7 +67,7 @@ namespace Chronic
         public static string Normalize(string phrase)
         {
             var normalized = phrase.ToLower();
-            normalized = phrase
+            normalized = normalized
                 .ReplaceAll(@"([/\-,@])", " " + "$1" + " ")
                 .ReplaceAll(@"['""\.,]", "")
                 .ReplaceAll(@"\bsecond (of|day|month|hour|minute|second)\b", "2nd $1")


### PR DESCRIPTION
Tests in BasicExpressionsTests.cs define the issue pretty well. This was written about at [Elegant Code](http://elegantcode.com/2012/02/01/nuget-project-uncovered-chronic/?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+ElegantCode+%28Elegant+Code%29).
Parser.cs also didn't have consistent line endings, this might make reading the diff a little bit harder, but I hope you won't mind.
