### PR TITLE
Added ability to handle long scale BIG numbers

### DIFF
--- a/src/Chronic.Tests/NumerizerTests.cs
+++ b/src/Chronic.Tests/NumerizerTests.cs
@@ -63,6 +63,23 @@ namespace Chronic.Tests
         }
 
         [Fact]
+        public void non_ordinal_numbers_are_parsed_correctly_long_scale()
+        {
+            new object[,]
+                {
+                    {"one milliard", 1000000000},
+                    {"one milliard and one", 1000000001},
+                    {"one billion", 1000000000000},
+                    {"one billion and one", 1000000000001}
+                }.ForEach<string, long>((phrase, expectedResult) =>
+                {
+                    var numerizedString = NumerizeLongScale(expectedResult, phrase);
+                    var number = ConvertToNumberLongScale(expectedResult, numerizedString, phrase);
+                    Assert.Equal(expectedResult, number);
+                });
+        }
+
+        [Fact]
         public void ordinal_numbers_are_parsed_correctly()
         {
             new[,]
@@ -106,12 +123,44 @@ namespace Chronic.Tests
             return value;
         }
 
+        static long ConvertToNumberLongScale(long r, string numerizedString, string s)
+        {
+            long value = 0;
+            if (!Int64.TryParse(numerizedString, out value))
+            {
+                throw new Exception(
+                    String.Format(
+                        "Numerized input '{0}' is expected to be an integral number but it's not. Test case: {1} => {2}",
+                        numerizedString,
+                        s,
+                        r));
+            }
+            return value;
+        }
+
         static string Numerize(int r, string s)
         {
             string numerizedInput = null;
             try
             {
                 numerizedInput = Numerizer.Numerize(s);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(
+                    String.Format(
+                        "Test case: {0} => {1} :: {2}", s, r, ex.Message),
+                    ex);
+            }
+            return numerizedInput;
+        }
+
+        static string NumerizeLongScale(long r, string s)
+        {
+            string numerizedInput = null;
+            try
+            {
+                numerizedInput = Numerizer.Numerize(s, true);
             }
             catch (Exception ex)
             {

--- a/src/Chronic/Numerizer.cs
+++ b/src/Chronic/Numerizer.cs
@@ -64,10 +64,19 @@ namespace Chronic
                 {"thousand", 1000},
                 {"million", 1000000},
                 {"billion", 1000000000},
-                {"trillion", 1000000000000},
+                {"trillion", 1000000000000}
             };
 
-        public static string Numerize(string value)
+        static readonly dynamic[,] BIG_PREFIXES_LONG = new dynamic[,]
+            {
+                {"hundred", 100},
+                {"thousand", 1000},
+                {"million", 1000000},
+                {"milliard", 1000000000},
+                {"billion", 1000000000000}
+            };
+
+        public static string Numerize(string value, bool longScale = false)
         {
             var result = value;
 
@@ -113,11 +122,19 @@ namespace Chronic
 
             // hundreds, thousands, millions, etc.
 
-            BIG_PREFIXES.ForEach<string, long>(
-                (p, r) =>
+            if(longScale)
+                BIG_PREFIXES_LONG.ForEach<string, long>(
+                    (p, r) =>
                     {
-                    result = Regex.Replace(result, @"(?:<num>)?(\d*) *" + p, match => "<num>" + (r * int.Parse(match.Groups[1].Value)).ToString());
-                    result = Andition(result);
+                        result = Regex.Replace(result, @"(?:<num>)?(\d*) *" + p, match => "<num>" + (r * int.Parse(match.Groups[1].Value)).ToString());
+                        result = Andition(result);
+                    });
+            else
+                BIG_PREFIXES.ForEach<string, long>(
+                    (p, r) =>
+                    {
+                        result = Regex.Replace(result, @"(?:<num>)?(\d*) *" + p, match => "<num>" + (r * int.Parse(match.Groups[1].Value)).ToString());
+                        result = Andition(result);
                     });
 
 

--- a/src/Chronic/Numerizer.cs
+++ b/src/Chronic/Numerizer.cs
@@ -126,7 +126,7 @@ namespace Chronic
                 BIG_PREFIXES_LONG.ForEach<string, long>(
                     (p, r) =>
                     {
-                        result = Regex.Replace(result, @"(?:<num>)?(\d*) *" + p, match => "<num>" + (r * int.Parse(match.Groups[1].Value)).ToString());
+                        result = Regex.Replace(result, @"(?:<num>)?(\d*) *" + p, match => "<num>" + (r * long.Parse(match.Groups[1].Value)).ToString());
                         result = Andition(result);
                     });
             else
@@ -156,7 +156,7 @@ namespace Chronic
                 if (match.Success == false)
                     break;
                 result = result.Substring(0, match.Index) + 
-                    "<num>" + ((int.Parse(match.Groups[1].Value) + int.Parse(match.Groups[3].Value)).ToString()) +
+                    "<num>" + ((int.Parse(match.Groups[1].Value) + long.Parse(match.Groups[3].Value)).ToString()) +
                     result.Substring(match.Index + match.Length);
             }
             return result;


### PR DESCRIPTION
Robert,
Your profile (and your last name :smile:) says you are from Poland so I realize you are aware of milliard, billiard, etc. (long scale.)  I also realize that this library is obviously targeted at English speaking locales since the words in the arrays in the Numerizer class are English (one, two, three,...)  Since there are extremely limited usages of long scale in English today you may not want to accept this pull request but I thought I would put it out there just in case.