### PR TITLE
Various improvements & bug fixes

### DIFF
--- a/src/Chronic.Tests/CustomParsingTest.cs
+++ b/src/Chronic.Tests/CustomParsingTest.cs
@@ -52,6 +52,12 @@ namespace Chronic.Tests
             Parse("two weeks ago")
                 .AssertEquals(Time.New(2006, 8, 02, 14));
         }
+        [Fact]
+        public void articles_are_normalized()
+        {
+            Parse("in a day").AssertStartsAt(Time.New(2006, 8, 17, 14));
+        }
+
 
         public class CanExtractTimeSpanFromSpan : ParsingTestsBase
         {

--- a/src/Chronic.Tests/Parsing/ComplexExpressionsTests.cs
+++ b/src/Chronic.Tests/Parsing/ComplexExpressionsTests.cs
@@ -9,8 +9,8 @@ namespace Chronic.Tests.Parsing
         static readonly TimeSpan TimeOfDay = new TimeSpan(15, 34, 44);
 
         protected override DateTime Now()
-        {
-            return Date.Add(TimeOfDay);
+        {            
+             return Date.Add(TimeOfDay);
         }
 
         [Fact]
@@ -39,6 +39,13 @@ namespace Chronic.Tests.Parsing
         {
             Parse("7 years ago").AssertStartsAt(
                 Time.New(2004, 10, 18, TimeOfDay));
+        }
+
+        [Fact]
+        public void this_week_parsed_correctly_on_last_day_of_week()
+        {
+            var date = new DateTime(2015, 6, 7, 3, 0, 0);
+            Parse("this week", new Options { Clock = () => date }).AssertStartsAt(new DateTime(2015, 6, 7));
         }
 
 

--- a/src/Chronic.Tests/Parsing/ComplexExpressionsTests.cs
+++ b/src/Chronic.Tests/Parsing/ComplexExpressionsTests.cs
@@ -9,8 +9,8 @@ namespace Chronic.Tests.Parsing
         static readonly TimeSpan TimeOfDay = new TimeSpan(15, 34, 44);
 
         protected override DateTime Now()
-        {            
-             return Date.Add(TimeOfDay);
+        {
+            return Date.Add(TimeOfDay);
         }
 
         [Fact]
@@ -46,8 +46,6 @@ namespace Chronic.Tests.Parsing
         {
             var date = new DateTime(2015, 6, 7, 3, 0, 0);
             Parse("this week", new Options { Clock = () => date }).AssertStartsAt(new DateTime(2015, 6, 7));
-        }
-
-
+        }     
     }
 }

--- a/src/Chronic.Tests/Parsing/KnownPatternsParsingTests.cs
+++ b/src/Chronic.Tests/Parsing/KnownPatternsParsingTests.cs
@@ -405,5 +405,19 @@ namespace Chronic.Tests.Parsing
 
             Parse("Ham Sandwich").AssertIsNull();
         }
+
+        [Fact]
+        public void ordinal_no_month()
+        {
+            Parse("the 1st")
+                .AssertStartsAt(Time.New(2006,9,1));
+
+            Parse("the 22nd")
+                .AssertStartsAt(Time.New(2006, 8, 22));
+
+            Parse("the 22nd at 3 pm")
+                .AssertStartsAt(Time.New(2006, 8, 22, 15,0,0));
+            
+        }
     }
 }

--- a/src/Chronic.Tests/Parsing/KnownPatternsParsingTests.cs
+++ b/src/Chronic.Tests/Parsing/KnownPatternsParsingTests.cs
@@ -426,5 +426,18 @@ namespace Chronic.Tests.Parsing
             Parse("next August")
                 .AssertStartsAt(Time.New(2007, 8, 1));
         }
+
+        [Fact]
+        public void ordinal_grabber_month_handler()
+        {
+            Parse("the 21st of next month")
+                .AssertEquals(Time.New(2006, 9, 21, 12));
+
+            Parse("the 21st of this month")
+                .AssertEquals(Time.New(2006, 8, 21, 12));
+
+            Parse("the 21st of last month")
+                .AssertEquals(Time.New(2006, 7, 21, 12));
+        }
     }
 }

--- a/src/Chronic.Tests/Parsing/KnownPatternsParsingTests.cs
+++ b/src/Chronic.Tests/Parsing/KnownPatternsParsingTests.cs
@@ -419,5 +419,12 @@ namespace Chronic.Tests.Parsing
                 .AssertStartsAt(Time.New(2006, 8, 22, 15,0,0));
             
         }
+
+        [Fact]
+        public void next_month_name_in_the_same_month_returns_next_year()
+        {
+            Parse("next August")
+                .AssertStartsAt(Time.New(2007, 8, 1));
+        }
     }
 }

--- a/src/Chronic/Chronic.csproj
+++ b/src/Chronic/Chronic.csproj
@@ -43,6 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EndianPrecedence.cs" />
+    <Compile Include="Handlers\OrdinalGrabberMonthHandler.cs" />
     <Compile Include="Handlers\GRGRHandler.cs" />
     <Compile Include="Handlers\MultiSRHandler.cs" />
     <Compile Include="Handlers\HandlerTypePattern.cs" />

--- a/src/Chronic/Handlers/OdRmnHandler.cs
+++ b/src/Chronic/Handlers/OdRmnHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Chronic.Tags.Repeaters;
@@ -9,15 +10,24 @@ namespace Chronic.Handlers
     {
         public Span Handle(IList<Token> tokens, Options options)
         {
-            var month = tokens[1].GetTag<RepeaterMonthName>();
             var day = tokens[0].GetTag<OrdinalDay>().Value;
+
             var now = options.Clock();
-            
+            var monthSpecified = tokens.Count > 1 && tokens[1].IsTaggedAs<RepeaterMonthName>();
+            var month = monthSpecified ? tokens[1].GetTag<RepeaterMonthName>() : GetMonth(day, now);            
+
             if (Time.IsMonthOverflow(now.Year, (int)month.Value, day))
             {
                 return null;
             }
-            return Utils.HandleMD(month, day, tokens.Skip(2).ToList(), options);
+            return Utils.HandleMD(month, day, tokens.Skip(monthSpecified ? 2 : 1).ToList(), options);
+        }
+
+        private RepeaterMonthName GetMonth(int day, DateTime now)
+        {          
+            if (now.Day < day)
+                return new RepeaterMonthName((MonthName)(now.Month));
+            return new RepeaterMonthName((MonthName)now.AddMonths(1).Month);
         }
     }
 }

--- a/src/Chronic/Handlers/OrdinalGrabberMonthHandler.cs
+++ b/src/Chronic/Handlers/OrdinalGrabberMonthHandler.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chronic.Tags.Repeaters;
+
+namespace Chronic.Handlers
+{
+    public class OrdinalGrabberMonthHandler: IHandler
+    {
+        public Span Handle(IList<Token> tokens, Options options)
+        {
+            var day = tokens[0].GetTag<OrdinalDay>().Value;
+            var outerSpan = tokens.Skip(1).Take(2).GetAnchor(options);
+            return Utils.DayOrTime(outerSpan.Start.Value.Date.AddDays(day - 1), new Token[0], options);
+        }
+    }
+}

--- a/src/Chronic/Handlers/Registration/MyHandlerRegistry.cs
+++ b/src/Chronic/Handlers/Registration/MyHandlerRegistry.cs
@@ -162,7 +162,7 @@ namespace Chronic.Handlers
                         .Using<OdRmnSyHandler>(),
                     Handle
                         .Required<OrdinalDay>()
-                        .Required<RepeaterMonthName>()
+                        .Optional<RepeaterMonthName>()
                         .Optional<SeparatorAt>()
                         .Optional(HandlerType.Time)
                         .Using<OdRmnHandler>(),

--- a/src/Chronic/Handlers/Registration/MyHandlerRegistry.cs
+++ b/src/Chronic/Handlers/Registration/MyHandlerRegistry.cs
@@ -245,6 +245,12 @@ namespace Chronic.Handlers
                         .Optional(HandlerType.Time)
                         .Using<MultiSRHandler>(),
 
+                    Handle
+                        .Required<OrdinalDay>()
+                        .Required<Grabber>()
+                        .Required<RepeaterMonth>()                        
+                        .Using<OrdinalGrabberMonthHandler>()
+
                     //Handle
                     //    .Required<ScalarMonth>()
                     //    .Required<SeparatorDate>()

--- a/src/Chronic/Tags/Repeaters/RepeaterMonthName.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterMonthName.cs
@@ -33,7 +33,7 @@ namespace Chronic.Tags.Repeaters
                     {
                         _currentMonthBegin = Time.New(Now.Value.Year, index);
                     }
-                    else if (now.Month > index)
+                    else if (now.Month >= index)
                     {
                         _currentMonthBegin = Time.New(Now.Value.Year + 1, index);
                     }

--- a/src/Chronic/Tags/Repeaters/RepeaterWeek.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterWeek.cs
@@ -96,9 +96,10 @@ namespace Chronic.Tags.Repeaters
                 thisWeekSpan = new Span(thisWeekStart, thisWeekEnd);
             }
             else if (pointer == Pointer.Type.None)
-            {
+            {                                
                 var sundayRepeater = new RepeaterDayName(GetStartOfWeek());
-                sundayRepeater.Now = now;
+                sundayRepeater.Now = (now.DayOfWeek == GetStartOfWeek()) ? now.AddDays(1).Date : now;
+                
                 Span lastSundaySpan = sundayRepeater.GetNextSpan(Pointer.Type.Past);
                 thisWeekStart = lastSundaySpan.Start.Value;
                 thisWeekEnd = thisWeekStart.AddDays(RepeaterWeek.WEEK_DAYS);
@@ -111,6 +112,7 @@ namespace Chronic.Tags.Repeaters
             return thisWeekSpan;
 
         }
+      
 
         public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
         {

--- a/src/Chronic/Tokenizer.cs
+++ b/src/Chronic/Tokenizer.cs
@@ -68,6 +68,7 @@ namespace Chronic
                 .ReplaceAll(@"\btonight\b", "this night")
                 .ReplaceAll(@"(\d)([ap]m|oclock)\b", "$1 $2")
                 .ReplaceAll(@"\b(hence|after|from)\b", "future")
+                .ReplaceAll(@"\ba (month|week|day|year)", "1 $1")
                 ;
 
             return normalized;


### PR DESCRIPTION
1) Add support for articles, like 'in a month', etc. (previously only 'in 1 month' worked)
2) Fixed a bug where 'this week' was wrong on the first day of the week (translated to the previous week)
3) Support for expressions like "on the 1st" (works like "on the 1st of June" if June is the current month)
4) fix an exception when parsing 'next June' while in June
5) add support for '21st of next month' type of expressions
