### PR TITLE
Simple multilanguage support

### DIFF
--- a/src/Chronic.Tests/Chronic.Tests.csproj
+++ b/src/Chronic.Tests/Chronic.Tests.csproj
@@ -58,6 +58,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MultilanguageParsingTest.cs" />
     <Compile Include="When.cs" />
     <Compile Include="CollectionExtensionTests.cs" />
     <Compile Include="Handlers\GRGRHandler_correctly_parses.cs" />

--- a/src/Chronic.Tests/MultilanguageParsingTest.cs
+++ b/src/Chronic.Tests/MultilanguageParsingTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+using Xunit;
+
+namespace Chronic.Tests
+{
+    public class MultilanguageParsingTest : ParsingTestsBase
+    {
+        protected override DateTime Now()
+        {
+            return Time.New(2006, 8, 16, 14, 0, 0);
+        }
+        
+
+        [Fact]
+        public void _2016_June_8_18_29_42()
+        {
+            var parsed = Parse("2016-June-8 18:29:42");
+            parsed.AssertStartsAt(Time.New(2016, 6, 8, 18, 29, 42));
+        }
+        [Fact]
+        public void _15_марта_2011()
+        {
+            var parsed = Parse("15 марта 2011", "ru");
+            parsed.AssertStartsAt(Time.New(2011, 3, 15));
+        }
+
+        [Fact]
+        public void miércoles_22_de_junio_de_2016()
+        {
+            var parsed = Parse("miércoles, 22 de junio de 2016", "es");
+            parsed.AssertStartsAt(Time.New(2016, 6, 22));
+        }
+    }
+}

--- a/src/Chronic.Tests/ParsingTestBase.cs
+++ b/src/Chronic.Tests/ParsingTestBase.cs
@@ -8,11 +8,12 @@ namespace Chronic.Tests
     {
         protected abstract DateTime Now();
 
-        protected Span Parse(string input)
+        protected Span Parse(string input, string locale = null)
         {
             Parser.IsDebugMode = true;
             var parser = new Parser(new Options
             {
+                Locale = locale,
                 Clock = () => Now(),
             });
             return parser.Parse(input);

--- a/src/Chronic/Chronic.csproj
+++ b/src/Chronic/Chronic.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Handlers\RdnRmnOdHandler.cs" />
     <Compile Include="Handlers\RdnRmnSdHandler.cs" />
     <Compile Include="Handlers\BCLDateTimeHandler.cs" />
+    <Compile Include="Handlers\RdnSdRmnSyTHandler.cs" />
     <Compile Include="Handlers\Registration\EndianSpecificRegistry.cs" />
     <Compile Include="Handlers\RepeatPattern.cs" />
     <Compile Include="Handlers\RGRHandler.cs" />
@@ -88,13 +89,21 @@
     <Compile Include="Handlers\SRPAHandler.cs" />
     <Compile Include="Handlers\SRPHandler.cs" />
     <Compile Include="Handlers\SyRmnOdHandler.cs" />
+    <Compile Include="Handlers\SyRmnSdTHandler.cs" />
     <Compile Include="Handlers\SySmSdHandler.cs" />
     <Compile Include="Handlers\Utils.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Numerizer.cs" />
     <Compile Include="Range.cs" />
+    <Compile Include="System\DateTimeFormatInfoHelpers.cs" />
     <Compile Include="System\Time.cs" />
     <Compile Include="System\TokenCollectionExtensions.cs" />
+    <Compile Include="Tags\Repeaters\Cultures\CultureItem.cs" />
+    <Compile Include="Tags\Repeaters\Cultures\CulturesPatterns.cs" />
+    <Compile Include="Tags\Repeaters\Patterns\DayOfWeekPattern.cs" />
+    <Compile Include="Tags\Repeaters\Patterns\DayPortionPattern.cs" />
+    <Compile Include="Tags\Repeaters\Patterns\MonthPattern.cs" />
+    <Compile Include="Tags\Repeaters\Patterns\UnitPattern.cs" />
     <Compile Include="Tags\TimeZone.cs" />
     <Compile Include="Tags\TimeZoneScanner.cs" />
     <Compile Include="Tags\GrabberScanner.cs" />
@@ -157,6 +166,7 @@
   <ItemGroup>
     <None Include="ultrico.snk" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Chronic/Handlers/RdnSdRmnSyTHandler.cs
+++ b/src/Chronic/Handlers/RdnSdRmnSyTHandler.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Chronic.Tags.Repeaters;
+
+namespace Chronic.Handlers
+{
+    public class RdnSdRmnSyTHandler : IHandler
+    {
+        public Span Handle(IList<Token> tokens, Options options)
+        {
+            var day = tokens[0].GetTag<RepeaterDayName>().Value;
+            var scalarDay = tokens[1].GetTag<ScalarDay>().Value;
+            var month = tokens[2].GetTag<RepeaterMonthName>();
+            var year = tokens[3].GetTag<ScalarYear>().Value;
+            var time_tokens = tokens.Skip(4).ToList();
+            if (Time.IsMonthOverflow(year, (int)month.Value, scalarDay))
+            {
+                return null;
+            }
+            try
+            {
+                var dayStart = Time.New(year, (int)month.Value, scalarDay);
+                return Utils.DayOrTime(dayStart, time_tokens, options);
+
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Chronic/Handlers/Registration/MyHandlerRegistry.cs
+++ b/src/Chronic/Handlers/Registration/MyHandlerRegistry.cs
@@ -271,7 +271,25 @@ namespace Chronic.Handlers
                     //    .Using<SdSmSyHandler>(),
 
 
+                   Handle
+                        .Required<RepeaterDayName>()
+                        .Required<ScalarDay>()
+                        .Optional<SeparatorDate>()
+                        .Required<RepeaterMonthName>()
+                        .Optional<SeparatorDate>()
+                        .Required<ScalarYear>()
+                        .Optional<SeparatorAt>()
+                        .Optional(HandlerType.Time)
+                        .Using<RdnSdRmnSyTHandler>(),
 
+                   Handle
+                    .Required<ScalarYear>()
+                    .Optional<SeparatorDate>()
+                    .Required<RepeaterMonthName>()
+                    .Required<SeparatorDate>()
+                    .Required<ScalarDay>()
+                    .Optional(HandlerType.Time)
+                    .Using<SyRmnSdTHandler>()
 
                 };
 

--- a/src/Chronic/Handlers/SyRmnSdTHandler.cs
+++ b/src/Chronic/Handlers/SyRmnSdTHandler.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Chronic.Tags.Repeaters;
+
+namespace Chronic.Handlers
+{
+    public class SyRmnSdTHandler : IHandler
+    {
+
+        public Span Handle(IList<Token> tokens, Options options)
+        {
+            var year = tokens[0].GetTag<ScalarYear>().Value;
+            var month = tokens[1].GetTag<RepeaterMonthName>();
+            var day = tokens[2].GetTag<ScalarDay>().Value;
+            var time_tokens = tokens.Skip(3).ToList();
+            if (Time.IsMonthOverflow(year, (int)month.Value, day))
+            {
+                return null;
+            }
+            try
+            {
+                var dayStart = Time.New(year, (int)month.Value, day);
+                return Utils.DayOrTime(dayStart, time_tokens, options);
+
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Chronic/Options.cs
+++ b/src/Chronic/Options.cs
@@ -5,6 +5,35 @@ namespace Chronic
 {
     public class Options
     {
+        private string _locale;
+        public string Locale
+        {
+            get
+            {
+                return _locale;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    _locale = string.Empty;
+                    return;
+                }
+
+                try
+                {
+                    var culture = CultureInfo.GetCultureInfo(value);
+                }
+                catch (CultureNotFoundException)
+                {
+                    _locale = string.Empty;
+                    return;
+                }
+
+                _locale = value;
+            }
+        }
+
         public static readonly int DefaultAmbiguousTimeRange = 6;
 
         public Func<DateTime> Clock { get; set; }
@@ -20,6 +49,7 @@ namespace Chronic
 
         public Options()
         {
+            Locale = string.Empty;
             AmbiguousTimeRange = DefaultAmbiguousTimeRange;
             EndianPrecedence = EndianPrecedence.Middle;
             Clock = () => DateTime.Now;

--- a/src/Chronic/System/DateTimeFormatInfoHelpers.cs
+++ b/src/Chronic/System/DateTimeFormatInfoHelpers.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Globalization;
+
+namespace Chronic
+{
+    public static class DateTimeFormatInfoHelpers
+    {
+        public static string GetMonthGenitiveName(this DateTimeFormatInfo dateTimeFormatInfo, int month)
+        {
+            if (month < 1 || month > 13)
+            {
+                throw new ArgumentOutOfRangeException("month", string.Format("Month argument should be between {0} and {1}", 1, 13));
+            }
+            return dateTimeFormatInfo.MonthGenitiveNames[month - 1];
+        }
+
+        public static string GeAbbreviatedMonthGenitiveName(this DateTimeFormatInfo dateTimeFormatInfo, int month)
+        {
+            if (month < 1 || month > 13)
+            {
+                throw new ArgumentOutOfRangeException("month", string.Format("Month argument should be between {0} and {1}", 1, 13));
+            }
+            return dateTimeFormatInfo.AbbreviatedMonthGenitiveNames[month - 1];
+        }
+    }
+}

--- a/src/Chronic/Tags/Repeaters/Cultures/CultureItem.cs
+++ b/src/Chronic/Tags/Repeaters/Cultures/CultureItem.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+using Chronic.Tags.Repeaters.Patterns;
+
+namespace Chronic.Tags.Repeaters.Cultures
+{
+    public class CultureItem
+    {
+        public List<MonthPattern> MonthPatterns { get; set; }
+
+        public List<DayOfWeekPattern> DayOfWeekPatterns { get; set; }
+    }
+}

--- a/src/Chronic/Tags/Repeaters/Cultures/CulturesPatterns.cs
+++ b/src/Chronic/Tags/Repeaters/Cultures/CulturesPatterns.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using Chronic.Tags.Repeaters.Patterns;
+
+namespace Chronic.Tags.Repeaters.Cultures
+{
+    public static class CulturesPatterns
+    {
+        private static readonly Dictionary<string, CultureItem> _allCultures = new Dictionary<string, CultureItem>();
+
+        public static CultureItem GetCultureItem(string culture)
+        {
+            if (!_allCultures.ContainsKey(culture))
+                _allCultures[culture] = GenerateCultureItem(culture);
+
+            return _allCultures[culture];
+
+        }
+
+        private static CultureItem GenerateCultureItem(string cultureTag)
+        {
+            var culture = CultureInfo.GetCultureInfo(cultureTag);
+            var dateTimeFormat = culture.DateTimeFormat;
+
+            var patternsForDayOfWeek = new List<DayOfWeekPattern>();
+
+            foreach (DayOfWeek day in Enum.GetValues(typeof(DayOfWeek)))
+            {
+                var longName = dateTimeFormat.GetDayName(day);
+                var abbreviateName = dateTimeFormat.GetAbbreviatedDayName(day);
+                patternsForDayOfWeek.Add(new DayOfWeekPattern() { Pattern = string.Format("^{0}$", longName).Compile(), Day = day });
+                patternsForDayOfWeek.Add(new DayOfWeekPattern() { Pattern = string.Format("^{0}$", abbreviateName).Compile(), Day = day });
+            }
+
+            var patternsForMonth = new List<MonthPattern>();
+            foreach (MonthName month in Enum.GetValues(typeof(MonthName)))
+            {
+                if (month == MonthName._ZERO_MONTH)
+                    continue;
+                var intMonth = (int)month;
+                var longName = dateTimeFormat.GetMonthGenitiveName(intMonth);
+                var abbreviateName = dateTimeFormat.GeAbbreviatedMonthGenitiveName(intMonth);
+                patternsForMonth.Add(new MonthPattern() { Pattern = string.Format("^{0}$", longName).Compile(), Month = month });
+                patternsForMonth.Add(new MonthPattern() { Pattern = string.Format("^{0}$", abbreviateName).Compile(), Month = month });
+            }
+
+            return new CultureItem() { DayOfWeekPatterns = patternsForDayOfWeek, MonthPatterns = patternsForMonth };
+
+        }
+    }
+}

--- a/src/Chronic/Tags/Repeaters/Patterns/DayOfWeekPattern.cs
+++ b/src/Chronic/Tags/Repeaters/Patterns/DayOfWeekPattern.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Chronic.Tags.Repeaters.Patterns
+{
+    public struct DayOfWeekPattern
+    {
+        public Regex Pattern;
+
+        public DayOfWeek Day;
+    }
+}

--- a/src/Chronic/Tags/Repeaters/Patterns/DayPortionPattern.cs
+++ b/src/Chronic/Tags/Repeaters/Patterns/DayPortionPattern.cs
@@ -1,0 +1,11 @@
+using System.Text.RegularExpressions;
+
+namespace Chronic.Tags.Repeaters.Patterns
+{
+    public struct DayPortionPattern
+    {
+        public Regex Pattern;
+
+        public DayPortion Portion;
+    }
+}

--- a/src/Chronic/Tags/Repeaters/Patterns/MonthPattern.cs
+++ b/src/Chronic/Tags/Repeaters/Patterns/MonthPattern.cs
@@ -1,0 +1,11 @@
+using System.Text.RegularExpressions;
+
+namespace Chronic.Tags.Repeaters.Patterns
+{
+    public struct MonthPattern
+    {
+        public Regex Pattern;
+
+        public MonthName Month;
+    }
+}

--- a/src/Chronic/Tags/Repeaters/Patterns/UnitPattern.cs
+++ b/src/Chronic/Tags/Repeaters/Patterns/UnitPattern.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Chronic.Tags.Repeaters.Patterns
+{
+    public struct UnitPattern
+    {
+        public Regex Pattern;
+
+        public Type Unit;
+    }
+}

--- a/src/Chronic/Tags/Repeaters/RepeaterScanner.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterScanner.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Chronic.Tags.Repeaters;
+
+using Chronic.Tags.Repeaters.Cultures;
+using Chronic.Tags.Repeaters.Patterns;
 
 namespace Chronic.Tags.Repeaters
 {
@@ -93,28 +95,46 @@ namespace Chronic.Tags.Repeaters
         static ITag ScanDayNames(Token token, Options options)
         {
             ITag tag = null;
-            DayPatterns.ForEach(item =>
+            foreach (var item in DayPatterns)
+            {
+                if (item.Pattern.IsMatch(token.Value))
                 {
-                    if (item.Pattern.IsMatch(token.Value))
-                    {
-                        tag = new RepeaterDayName(item.Day);
-                        return;
-                    }
-                });
+                    return new RepeaterDayName(item.Day);
+                }
+            }
+
+            // next search in localized days
+            foreach (var item in CulturesPatterns.GetCultureItem(options.Locale).DayOfWeekPatterns)
+            {
+                if (item.Pattern.IsMatch(token.Value))
+                {
+                    return new RepeaterDayName(item.Day);
+                }
+            }
+
             return tag;
         }
 
         static ITag ScanMonthNames(Token token, Options options)
         {
             ITag tag = null;
-            MonthPatterns.ForEach(item =>
+            foreach (var item in MonthPatterns)
+            {
+                if (item.Pattern.IsMatch(token.Value))
                 {
-                    if (item.Pattern.IsMatch(token.Value))
-                    {
-                        tag = new RepeaterMonthName(item.Month);
-                        return;
-                    }
-                });
+                    return new RepeaterMonthName(item.Month);
+                }
+            }
+
+            // next search in localized months
+            foreach (var item in CulturesPatterns.GetCultureItem(options.Locale).MonthPatterns)
+            {
+                if (item.Pattern.IsMatch(token.Value))
+                {
+                    return new RepeaterMonthName(item.Month);
+                }
+            }
+
             return tag;
         }
 
@@ -126,62 +146,60 @@ namespace Chronic.Tags.Repeaters
         static readonly Regex _timePattern =
             @"^\d{1,2}(:?\d{2})?([\.:]?\d{2})?$".Compile();
 
-        static readonly List<dynamic> DayPortionPatterns = new List<dynamic>
+        static readonly List<DayPortionPattern> DayPortionPatterns = new List<DayPortionPattern>
             {
-                new {Pattern = "^ams?$".Compile(), Portion = DayPortion.AM},
-                new {Pattern = "^pms?$".Compile(), Portion = DayPortion.PM},
-                new {Pattern = "^mornings?$".Compile(), Portion = DayPortion.MORNING},
-                new {Pattern = "^afternoons?$".Compile(), Portion = DayPortion.AFTERNOON},
-                new {Pattern = "^evenings?$".Compile(), Portion = DayPortion.EVENING},
-                new {Pattern = "^(night|nite)s?$".Compile(), Portion = DayPortion.NIGHT},
+                new DayPortionPattern{ Pattern = "^ams?$".Compile(), Portion = DayPortion.AM },
+                new DayPortionPattern{ Pattern = "^pms?$".Compile(), Portion = DayPortion.PM },
+                new DayPortionPattern{ Pattern = "^mornings?$".Compile(), Portion = DayPortion.MORNING },
+                new DayPortionPattern{ Pattern = "^afternoons?$".Compile(), Portion = DayPortion.AFTERNOON },
+                new DayPortionPattern{ Pattern = "^evenings?$".Compile(), Portion = DayPortion.EVENING },
+                new DayPortionPattern{ Pattern = "^(night|nite)s?$".Compile(), Portion = DayPortion.NIGHT },
             };
 
-        static readonly List<dynamic> DayPatterns = new List<dynamic>
+        static readonly List<DayOfWeekPattern> DayPatterns = new List<DayOfWeekPattern>
             {
-                new {Pattern ="^m[ou]n(day)?$".Compile(), Day = DayOfWeek.Monday},
-                new {Pattern = "^t(ue|eu|oo|u|)s(day)?$".Compile(), Day = DayOfWeek.Tuesday},
-                new {Pattern = "^tue$".Compile(), Day = DayOfWeek.Tuesday},
-                new {Pattern = "^we(dnes|nds|nns)day$".Compile(), Day = DayOfWeek.Wednesday},
-                new {Pattern = "^wed$".Compile(), Day = DayOfWeek.Wednesday},
-                new {Pattern = "^th(urs|ers)day$".Compile(), Day = DayOfWeek.Thursday},
-                new {Pattern = "^thu$".Compile(), Day = DayOfWeek.Thursday},
-                new {Pattern = "^fr[iy](day)?$".Compile(), Day = DayOfWeek.Friday},
-                new {Pattern = "^sat(t?[ue]rday)?$".Compile(), Day = DayOfWeek.Saturday},
-                new {Pattern = "^su[nm](day)?$".Compile(), Day = DayOfWeek.Sunday},
+                new DayOfWeekPattern{ Pattern = "^m[ou]n(day)?$".Compile(), Day = DayOfWeek.Monday },
+                new DayOfWeekPattern{ Pattern = "^t(ue|eu|oo|u|)s(day)?$".Compile(), Day = DayOfWeek.Tuesday },
+                new DayOfWeekPattern{ Pattern = "^tue$".Compile(), Day = DayOfWeek.Tuesday },
+                new DayOfWeekPattern{ Pattern = "^we(dnes|nds|nns)day$".Compile(), Day = DayOfWeek.Wednesday },
+                new DayOfWeekPattern{ Pattern = "^wed$".Compile(), Day = DayOfWeek.Wednesday },
+                new DayOfWeekPattern{ Pattern = "^th(urs|ers)day$".Compile(), Day = DayOfWeek.Thursday },
+                new DayOfWeekPattern{ Pattern = "^thu$".Compile(), Day = DayOfWeek.Thursday },
+                new DayOfWeekPattern{ Pattern = "^fr[iy](day)?$".Compile(), Day = DayOfWeek.Friday },
+                new DayOfWeekPattern{ Pattern = "^sat(t?[ue]rday)?$".Compile(), Day = DayOfWeek.Saturday },
+                new DayOfWeekPattern{ Pattern = "^su[nm](day)?$".Compile(), Day = DayOfWeek.Sunday }
+
             };
 
-        static readonly List<dynamic> MonthPatterns = new List<dynamic>
+        static readonly List<MonthPattern> MonthPatterns = new List<MonthPattern>
             {
-                new {Pattern = "^jan\\.?(uary)?$".Compile(), Month = MonthName.January},
-                new {Pattern = "^feb\\.?(ruary)?$".Compile(), Month = MonthName.February},
-                new {Pattern = "^mar\\.?(ch)?$".Compile(), Month = MonthName.March},
-                new {Pattern = "^apr\\.?(il)?$".Compile(), Month = MonthName.April},
-                new {Pattern = "^may$".Compile(), Month = MonthName.May},
-                new {Pattern = "^jun\\.?e?$".Compile(), Month = MonthName.June},
-                new {Pattern = "^jul\\.?y?$".Compile(), Month = MonthName.July},
-                new {Pattern = "^aug\\.?(ust)?$".Compile(), Month = MonthName.August},
-                new
-                    {
-                        Pattern = "^sep\\.?(t\\.?|tember)?$".Compile(),
-                        Month = MonthName.September
-                    },
-                new {Pattern = "^oct\\.?(ober)?$".Compile(), Month = MonthName.October},
-                new {Pattern = "^nov\\.?(ember)?$".Compile(), Month = MonthName.November},
-                new {Pattern = "^dec\\.?(ember)?$".Compile(), Month = MonthName.December},
+                new MonthPattern{ Pattern = "^jan\\.?(uary)?$".Compile(), Month = MonthName.January },
+                new MonthPattern{ Pattern = "^feb\\.?(ruary)?$".Compile(), Month = MonthName.February },
+                new MonthPattern{ Pattern = "^mar\\.?(ch)?$".Compile(), Month = MonthName.March },
+                new MonthPattern{ Pattern = "^apr\\.?(il)?$".Compile(), Month = MonthName.April },
+                new MonthPattern{ Pattern = "^may$".Compile(), Month = MonthName.May },
+                new MonthPattern{ Pattern = "^jun\\.?e?$".Compile(), Month = MonthName.June },
+                new MonthPattern{ Pattern = "^jul\\.?y?$".Compile(), Month = MonthName.July },
+                new MonthPattern{ Pattern = "^aug\\.?(ust)?$".Compile(), Month = MonthName.August },
+                new MonthPattern{ Pattern = "^sep\\.?(t\\.?|tember)?$".Compile(), Month = MonthName.September },
+                new MonthPattern{ Pattern = "^oct\\.?(ober)?$".Compile(), Month = MonthName.October },
+                new MonthPattern{ Pattern = "^nov\\.?(ember)?$".Compile(), Month = MonthName.November },
+                new MonthPattern{ Pattern = "^dec\\.?(ember)?$".Compile(), Month = MonthName.December }
+
             };
 
-        static readonly List<dynamic> UnitPatterns = new List<dynamic>
+        static readonly List<UnitPattern> UnitPatterns = new List<UnitPattern>
             {
-                new { Pattern = "^years?$".Compile(), Unit = typeof(RepeaterYear) },
-                new { Pattern = "^seasons?$".Compile(), Unit = typeof(RepeaterSeason) },
-                new { Pattern = "^months?$".Compile(), Unit = typeof(RepeaterMonth) },
-                new { Pattern = "^fortnights?$".Compile(), Unit = typeof(RepeaterFortnight) },
-                new { Pattern = "^weeks?$".Compile(), Unit = typeof(RepeaterWeek) },
-                new { Pattern = "^weekends?$".Compile(), Unit = typeof(RepeaterWeekend) },
-                new { Pattern = "^days?$".Compile(), Unit = typeof(RepeaterDay) },
-                new { Pattern = "^hours?$".Compile(), Unit = typeof(RepeaterHour) },
-                new { Pattern = "^minutes?$".Compile(), Unit = typeof(RepeaterMinute) },
-                new { Pattern = "^seconds?$".Compile(), Unit = typeof(RepeaterSecond) }
+                new UnitPattern{ Pattern = "^years?$".Compile(), Unit = typeof(RepeaterYear) },
+                new UnitPattern{ Pattern = "^seasons?$".Compile(), Unit = typeof(RepeaterSeason) },
+                new UnitPattern{ Pattern = "^months?$".Compile(), Unit = typeof(RepeaterMonth) },
+                new UnitPattern{ Pattern = "^fortnights?$".Compile(), Unit = typeof(RepeaterFortnight) },
+                new UnitPattern{ Pattern = "^weeks?$".Compile(), Unit = typeof(RepeaterWeek) },
+                new UnitPattern{ Pattern = "^weekends?$".Compile(), Unit = typeof(RepeaterWeekend) },
+                new UnitPattern{ Pattern = "^days?$".Compile(), Unit = typeof(RepeaterDay) },
+                new UnitPattern{ Pattern = "^hours?$".Compile(), Unit = typeof(RepeaterHour) },
+                new UnitPattern{ Pattern = "^minutes?$".Compile(), Unit = typeof(RepeaterMinute) },
+                new UnitPattern{ Pattern = "^seconds?$".Compile(), Unit = typeof(RepeaterSecond) }
             };
     }
 }

--- a/src/Chronic/Tags/SeparatorScanner.cs
+++ b/src/Chronic/Tags/SeparatorScanner.cs
@@ -14,6 +14,9 @@ namespace Chronic
                 new { Pattern = @"^/$".Compile(), Tag = new SeparatorDate(Separator.Type.Slash) },
                 new { Pattern = @"^-$".Compile(), Tag = new SeparatorDate(Separator.Type.Dash) },
                 new { Pattern = @"^on$".Compile(), Tag = new SeparatorOn() },
+
+                // spanish month and year prefix
+                new { Pattern = @"^de$".Compile(), Tag = new SeparatorDate(Separator.Type.At) },
             };
 
         public IList<Token> Scan(IList<Token> tokens, Options options)


### PR DESCRIPTION
Adding simple multi-language support for week days and month names
- locale can be set in Options (RFC 1766 standard)
- additional Handlers added (RdnSdRmnSyTHandler.cs, SyRmnSdTHandler.cs)
- dynamic classes in RepeaterScanner replaced with structures
- improve performance of ScanDayNamesand ScanMonthNames - now return just after match founded
