### PR TITLE
Change the DateTimeKind to Local for all DateTimes

### DIFF
--- a/src/Chronic/System/Time.cs
+++ b/src/Chronic/System/Time.cs
@@ -68,7 +68,7 @@ namespace Chronic
                 }
 
             }
-            return new DateTime(year, month, day, hour, minute, second);
+            return new DateTime(year, month, day, hour, minute, second, DateTimeKind.Local);
         }
 
         public static bool IsMonthOverflow(int year, int month, int day)


### PR DESCRIPTION
Currently the DateTimeKind varies based on what is parsed. "Now" produces a kind of "Local" while "3 pm" produces a kind of "Unspecified".